### PR TITLE
Add a spec around the headers and the base64 require

### DIFF
--- a/lib/docker_cloud.rb
+++ b/lib/docker_cloud.rb
@@ -31,6 +31,9 @@ require 'docker_cloud/api/container_api'
 require 'docker_cloud/api/stack_api'
 require 'docker_cloud/api/registry_api'
 
+# ruby libs
+require 'base64'
+
 module DockerCloud
   class Client
     attr_reader :username

--- a/spec/docker_cloud_spec.rb
+++ b/spec/docker_cloud_spec.rb
@@ -9,3 +9,15 @@ describe DockerCloud do
     expect(false).to eq(true)
   end
 end
+
+describe DockerCloud::Client do
+  describe "#headers" do
+    subject { described_class.new('foo', 'bar').headers }
+
+    context "Authorization header" do
+      it "base64 encodes username and api_key" do
+        expect(subject["Authorization"]).to eq("Basic Zm9vOmJhcg==")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We started using your gem and found it requires base64 to work.  Here's a spec and the missing require statement.
