### PR TITLE
Container exec

### DIFF
--- a/lib/docker_cloud.rb
+++ b/lib/docker_cloud.rb
@@ -30,6 +30,7 @@ require 'docker_cloud/api/node_api'
 require 'docker_cloud/api/external_repository_api'
 require 'docker_cloud/api/service_api'
 require 'docker_cloud/api/container_api'
+require 'docker_cloud/api/container_stream_api'
 require 'docker_cloud/api/stack_api'
 require 'docker_cloud/api/registry_api'
 require 'docker_cloud/api/events_api'
@@ -46,6 +47,7 @@ module DockerCloud
       REPOSITORY = 'repo'.freeze
       APPLICATION = 'app'.freeze
       AUDIT = 'audit'.freeze
+      CONTAINER = 'container'.freeze
     end
 
     def initialize(username, api_key)

--- a/lib/docker_cloud.rb
+++ b/lib/docker_cloud.rb
@@ -107,7 +107,7 @@ module DockerCloud
     end
 
     def events
-      @containers ||= DockerCloud::EventsAPI.new(headers, ApiType::AUDIT, self)
+      @events ||= DockerCloud::EventsAPI.new(headers, ApiType::AUDIT, self)
     end
 
     private

--- a/lib/docker_cloud/api/container_stream_api.rb
+++ b/lib/docker_cloud/api/container_stream_api.rb
@@ -1,0 +1,19 @@
+module DockerCloud
+  class ContainerStreamAPI < DockerCloud::StreamAPI
+    def initialize(uuid, command, headers, client)
+      @uuid = uuid
+      @command = command
+      super(headers, DockerCloud::Client::ApiType::CONTAINER, client)
+    end
+
+    private
+
+    def websocket_path
+      @websocket_path ||= "/container/#{@uuid}/exec?command=#{@command}"
+    end
+
+    def root_path
+      'app'
+    end
+  end
+end

--- a/lib/docker_cloud/api/events_api.rb
+++ b/lib/docker_cloud/api/events_api.rb
@@ -10,6 +10,10 @@ module DockerCloud
       @websocket_path ||= '/events'.freeze
     end
 
+    def root_path
+      'audit'
+    end
+
     def _on_message(event)
       @listeners[:message].call(convert_to_dockercloud_event(event)) if @listeners[:message]
     end

--- a/lib/docker_cloud/api/stream_api.rb
+++ b/lib/docker_cloud/api/stream_api.rb
@@ -4,7 +4,7 @@ module DockerCloud
 
     def websocket
       @websocket ||= begin
-        url = URI.escape(STREAM_API_PATH + '/' + @type + '/' + API_VERSION + websocket_path)
+        url = URI.escape(STREAM_API_PATH + '/' + root_path + '/' + API_VERSION + websocket_path)
         Faye::WebSocket::Client.new(url, nil, ping: 240, headers: headers)
       end
     end

--- a/spec/docker_cloud/api/container_stream_api_spec.rb
+++ b/spec/docker_cloud/api/container_stream_api_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe DockerCloud::ContainerStreamAPI do
+  subject { DockerCloud::ContainerStreamAPI.new(uuid, command, headers, client) }
+  let(:uuid) { '1234' }
+  let(:command) { 'ls' }
+  let(:headers) { {} }
+  let(:client) { instance_double(DockerCloud::Client) }
+  let(:faye_client) { instance_double(Faye::WebSocket::Client, on: nil) }
+
+  describe '#websocket' do
+    it 'initializes Faye with the correct URL' do
+      expect(Faye::WebSocket::Client).to receive(:new).with('wss://ws.cloud.docker.com/api/app/v1/container/1234/exec?command=ls', nil, ping: 240, headers: headers).and_return(faye_client)
+
+      subject.websocket
+    end
+  end
+
+  # NOTE: We're testing the class our class has to inherit from here
+  describe '#run!' do
+    before do
+      # Set a no-op listener because `run!` requires at least
+      # one listener to exist.
+      subject.on(:message) {}
+    end
+
+    it 'creates a websocket using faye' do
+      expect(Faye::WebSocket::Client).to receive(:new).with('wss://ws.cloud.docker.com/api/app/v1/container/1234/exec?command=ls', nil, ping: 240, headers: headers).and_return(faye_client)
+
+      subject.run! { EM.add_timer(0.5) { EventMachine.stop } }
+    end
+
+    it 'invokes our optional blocks' do
+      received = false
+      subject.run! do
+        received = true
+        EM.add_timer(0.5) { EventMachine.stop }
+      end
+      expect(received).to be_truthy
+    end
+
+    it 'triggers our message callbacks' do
+
+    end
+  end
+end

--- a/spec/docker_cloud/api/container_stream_api_spec.rb
+++ b/spec/docker_cloud/api/container_stream_api_spec.rb
@@ -38,9 +38,5 @@ describe DockerCloud::ContainerStreamAPI do
       end
       expect(received).to be_truthy
     end
-
-    it 'triggers our message callbacks' do
-
-    end
   end
 end

--- a/spec/docker_cloud/api/events_api_spec.rb
+++ b/spec/docker_cloud/api/events_api_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe DockerCloud::EventsAPI do
+  subject { DockerCloud::EventsAPI.new(headers, type, client) }
+  let(:type) { 'container' }
+  let(:headers) { {} }
+  let(:client) { instance_double(DockerCloud::Client) }
+  let(:faye_client) { instance_double(Faye::WebSocket::Client, on: nil) }
+
+  describe '#websocket' do
+    it 'initializes Faye with the correct URL' do
+      expect(Faye::WebSocket::Client).to receive(:new).with('wss://ws.cloud.docker.com/api/audit/v1/events', nil, ping: 240, headers: headers).and_return(faye_client)
+
+      subject.websocket
+    end
+  end
+end


### PR DESCRIPTION
Added the ability to execute a command on a container on docker cloud.
We're doing this to enable adding/removing servers from haproxy for blue/green deploys.
We use it like this:

```
$LOAD_PATH.unshift File.dirname(__FILE__)
require 'docker_cloud'
require 'json'
require 'csv'

dc_user = 'testuser'
dc_key = 'testkey'
container_id = 'container-id'

client = DockerCloud::Client.new(dc_user, dc_key)
cmd = 'sh -c "echo show stat | nc -U /var/run/haproxy.stats"'
api = DockerCloud::ContainerStreamAPI.new(container_id, cmd, client.headers, client)
acc_data = ''

def parse_data(data)
  csv = CSV.parse(data, headers: true)
  csv.each do |line|
    puts "#{line['# pxname']}:#{line['svname']} is #{line['status']}" unless line.empty?
  end
end

api.on(:message) do |event|
  data = JSON.parse(event.data)['output']
  acc_data << data
end

api.on(:open) { |x| puts "Socket Opened" }
api.on(:error) { |x| puts "ERROR: #{x.message}" }
api.on(:close) do |x|
  puts 'Socket Closed'
  api = nil
  parse_data(acc_data)
  exit
end

api.run!
```
